### PR TITLE
Add restitution (elasticity)

### DIFF
--- a/cpp/JSIBox2dFixtureDef.h
+++ b/cpp/JSIBox2dFixtureDef.h
@@ -27,10 +27,15 @@ namespace Box2d {
             getObject()->friction = value.asNumber();
         }
 
+        JSI_PROPERTY_SET(restitution) {
+            getObject()->restitution = value.asNumber();
+        }
+
         JSI_EXPORT_PROPERTY_SETTERS(
                 JSI_EXPORT_PROP_SET(JSIBox2dFixtureDef, shape),
                 JSI_EXPORT_PROP_SET(JSIBox2dFixtureDef, density),
-                JSI_EXPORT_PROP_SET(JSIBox2dFixtureDef, friction))
+                JSI_EXPORT_PROP_SET(JSIBox2dFixtureDef, friction),
+                JSI_EXPORT_PROP_SET(JSIBox2dFixtureDef, restitution))
 
         /**
          * Constructor

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,11 @@ export interface b2FixtureDef {
   friction: number;
 
   /**
+   * The restitution (elasticity) usually in the range [0,1].
+   **/
+  restitution: number;
+
+  /**
    * The shape, this must be set. The shape will be cloned, so you can create the shape on the stack.
    **/
   shape: b2Shape;


### PR DESCRIPTION
This PR exposes `restitution` (elasticity) parameter.

Example usage:

```tsx
const fixtureDef = Box2d.b2FixtureDef();
fixtureDef.restitution = 0.5;
```