### PR TITLE
Add polygon shape from points

### DIFF
--- a/cpp/JSIBox2dPolygonShape.h
+++ b/cpp/JSIBox2dPolygonShape.h
@@ -20,7 +20,21 @@ namespace Box2d {
             return jsi::Value::undefined();
         }
 
-        JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JSIBox2dPolygonShape, SetAsBox))
+        JSI_HOST_FUNCTION(Set) {
+            auto array = arguments[0].asObject(runtime).asArray(runtime);
+            auto n = static_cast<int32>(array.length(runtime));
+            b2Vec2 points[n];
+            for (int32 i = 0; i < n; ++i) {
+              auto point = JSIBox2dVec2::fromValue(runtime, array.getValueAtIndex(runtime, i));
+              points[i].x = point->x;
+              points[i].y = point->y;
+            }
+            getObject()->Set(points, n);
+            return jsi::Value::undefined();
+        }
+
+        JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JSIBox2dPolygonShape, SetAsBox),
+                             JSI_EXPORT_FUNC(JSIBox2dPolygonShape, Set))
 
         /**
          * Constructor

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,13 @@ export interface b2PolygonShape extends b2Shape {
    * @return Box polygon shape.
    **/
   SetAsBox(hx: number, hy: number): void;
+
+  /**
+   * Create a convex hull from the given array of local points. The count must be in the range [3, b2_maxPolygonVertices].
+   * @param points The array of local points.
+   * @return Polygon shape.
+   **/
+  Set(points: b2Vec2[]): void;
 }
 
 export interface b2FixtureDef {


### PR DESCRIPTION
This PR exposes `Set` method which allows to create a polygon shape from an array of local points.

Example usage:

```tsx
const shape = Box2d.b2PolygonShape();
shape.Set([
  Box2d.b2Vec2(0.0, 0.0),
  Box2d.b2Vec2(1.0, 0.0),
  Box2d.b2Vec2(1.0, 1.0),
]);
```